### PR TITLE
create_category

### DIFF
--- a/app/controllers/admins/categories_controller.rb
+++ b/app/controllers/admins/categories_controller.rb
@@ -1,4 +1,23 @@
 class Admins::CategoriesController < ApplicationController
+  
   def index
+  	@category =Category.new
   end
+
+  def create
+  	@category =Category.new(category_params)
+  	if @category.save 
+  		redirect_to admins_categories_path
+  	else
+      flash[:notice]="errors"
+  		render 'index'
+    end
+  end
+
+  private
+
+  def category_params
+  	params.require(:category).permit(:name,:category_status)
+  end
+
 end

--- a/app/models/admin.rb
+++ b/app/models/admin.rb
@@ -3,4 +3,6 @@ class Admin < ApplicationRecord
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+
+
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,2 +1,8 @@
 class Category < ApplicationRecord
+  #ステータスのenum
+  enum category_status:{'有効':0,'無効':1}
+  
+  validates :name, presence: true
+  
+
 end

--- a/app/views/admins/categories/index.html.erb
+++ b/app/views/admins/categories/index.html.erb
@@ -1,2 +1,16 @@
 <h1>Admins::Categories#index</h1>
-<p>Find me in app/views/admins/categories/index.html.erb</p>
+<h3>ジャンル一覧</h3>
+
+<div>
+	<%= form_for @category,:url => {:action => :create} do |f| %>
+		<%= f.label :name %>
+		<%= f.text_field :name %>
+		<%= f.select :category_status, Category.category_statuses.keys, include_blank: "-----" %>
+
+		<%= f.submit %>
+	<% end %>
+</div>
+
+
+
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,25 +14,19 @@ Rails.application.routes.draw do
     registrations: 'users/registrations'
   }
 #------------------------------------------------------------
+  root 'top#home'
+
+# admins--------------------------------------------
 
   namespace :admins do
-    get 'users/index'
-    get 'users/show'
-  end
-  namespace :admins do
-    get 'orders/index'
-    get 'orders/show'
-  end
-  namespace :admins do
-    get 'categories/index'
-  end
-  namespace :admins do
-    get 'products/index'
-    get 'products/show'
-    get 'products/new'
-    get 'products/edit'
-  end
-  namespace :admins do
+    resources :users, only: [:index,:show,:edit,:update,:destroy,:create]
+  
+    resources :orders, only: [:index,:show,:update,:destroy,:create]
+  
+    resources :categories, only: [:index,:edit,:update,:destroy,:create]
+
+    resources :categories, only: [:index,:edit,:new,:update,:destroy,:create]
+
     get 'homes/top'
   end
 


### PR DESCRIPTION
カテゴリーの入力フォームの追加
adminのルーティングでresourcesに変更
カテゴリーモデルにバリデーションとenumを記入
[メモ]
・有効無効のステータスにはenumのプルダウンを採用（ラジオボタンのやり方わからず、、）
・adminでform_forをやろうとすると「undefined method `categories_path' for create」とエラーが出たが、adminでcreateをする場合はURLが「/admins/categories」になるので、送り先を指定してあげた。<%= form_for @category,:url => {:action => :create} do |f| %>としたらできた。