### PR TITLE
fix delivery

### DIFF
--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -11,17 +11,37 @@ class OrdersController < ApplicationController
 #-----------------------------------------------------------
 
 #注文作成----------------------------------------------------
-  
+
   # (GET)注文情報入力表示--------------0
   def new
-    @order = Order.new
-    @order.order_details.build
+    @order = Order.new #(注文情報入力用)
+    # @order.order_details.build いらないはず
+    @delivery_addresses = DeliveryAddress.where(user_id: current_user.id)
+
+    @delivery_address = DeliveryAddress.new #(3)新規配達先用
   end
  # (POST)注文確認画面表示--------------------0
   def confirmation
-  	@carts = Cart.where(user_id: current_user.id)
-  	@order = Order.new(order_params)
-  	render 'orders/confirmation'
+    option = params[:option] #どの方法で配達先を選択したか受け取る。
+    if option == "1"  #(1)完成! ユーザーの住所をorderに入れる。
+      @order = Order.new(order_params)
+      @order.receiver = current_user.user_fullname 
+      @order.postal_code = current_user.postal_code
+      @order.delivery_address = current_user.user_address
+    elsif option == "2" #(2)完成! 既存の配達先から選ぶ
+      address_select = DeliveryAddress.find(params[:address_select])
+      @order = Order.new(order_params)
+      @order.receiver = address_select.receiver
+      @order.postal_code = address_select.postal_code
+      @order.delivery_address = address_select.connect_address
+    else #(3)完成！ 新規の住所をaddress_paramsで受け取りorderに入れる。
+      @order = Order.new(order_params)
+      address = DeliveryAddress.new(address_params)
+      @order.postal_code = address.postal_code
+      @order.delivery_address = address.connect_address
+  	end
+      @carts = Cart.where(user_id: current_user.id)
+  	  render 'orders/confirmation' #カート情報と注文情報をviewに渡し再度隠しフォームに入れる。
   end
   # (POST)注文データ作成→注文確定ページ表示---------0
   def create
@@ -48,4 +68,7 @@ class OrdersController < ApplicationController
   	params.require(:order).permit(:payment, :receiver, :postal_code, :delivery_address)
   end
 
+  def address_params
+    params.require(:delivery_address).permit(:postal_code, :prefecture_code, :address_city, :address_street, :address_building)
+  end
 end

--- a/app/models/delivery_address.rb
+++ b/app/models/delivery_address.rb
@@ -1,7 +1,27 @@
 class DeliveryAddress < ApplicationRecord
   belongs_to :user
   
-  def delivery_address
+  include JpPrefecture
+  jp_prefecture :prefecture_code
+
+  def prefecture_name
+    JpPrefecture::Prefecture.find(code: prefecture_code).try(:name)
+  end
+
+  def prefecture_name=(prefecture_name)
+   self.prefecture_code = JpPrefecture::Prefecture.find(name: prefecture_name).code
+  end
+
+  def connect_address
     [self.prefecture_name, self.address_city, self.address_street, self.address_building].compact.join
   end
+#住所選択のプルダウン用
+  def pulldown_content
+    [self.postal_code, self.connect_address, self.receiver ].compact.join(" ")
+  end
+  #プルダウンで使うように配列に入れる。
+  def pullarray_address
+    [self.pulldown_content, self.id ]
+  end
+
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,7 +17,7 @@ class User < ApplicationRecord
   jp_prefecture :prefecture_code
 
   def prefecture_name
- 　  JpPrefecture::Prefecture.find(code: prefecture_code).try(:name)
+   JpPrefecture::Prefecture.find(code: prefecture_code).try(:name)
   end
 
   def prefecture_name=(prefecture_name)
@@ -27,7 +27,11 @@ class User < ApplicationRecord
 
 #住所カラムの連結
   def user_address
-    [self.prefecture_code, self.address_city, self.address_street, self.address_building].compact.join
+    [self.prefecture_name, self.address_city, self.address_street, self.address_building].compact.join
+  end
+#名前の連結(使い方： @user.user_fullname →　フルネームが表示される。)
+  def user_fullname
+    [self.family_name, self.first_name].compact.join
   end
 
 

--- a/app/views/orders/index.html.erb
+++ b/app/views/orders/index.html.erb
@@ -24,7 +24,7 @@
 			  	<td>
 			  		<p><%= order.postal_code %></p>
 			  		<p><%= order.delivery_address %></p>
-			  		<p><%= order.user.family_name%><%= order.user.first_name%></p>
+			  		<p><%= order.receiver %></p>
 			  	</td>
 			  	<td>
 			  		<% order.order_details.each do |order_detail| %>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -1,13 +1,48 @@
 <div class="row">
   <h2>注文情報入力</h2>
+</div>
+<div class="row">
   <%= form_for @order, url: orders_confirmation_path do |f| %>
+  <!-- --------------------------------支払い方法選択-------------------------------------- -->
+    <h3>支払い方法</h3>
     <%= f.radio_button :payment, "クレジットカード" %><span>クレジットカード</span><br>
-    <%= f.radio_button :payment, "銀行振り込み" %><span>銀行振り込み</span>
-    
-    <h3>届け先</h3>
+    <%= f.radio_button :payment, "銀行振り込み" %><span>銀行振り込み</span><br>
+
+  <!-- ----------------------------------届け先選択---------------------------------------- -->
+    <h3>お届け先</h3>
+    <!-- --------------------(1)自分の住所を選択--------------------------- -->
+    <h5><%= radio_button_tag :option, "1", name="option" %> ご自身の住所</h5>
+
+    <p><%= current_user.user_address %></p>
+    <!-- ---------------------(2)登録した住所から選択------------------------ -->
+    <h5><%= radio_button_tag :option, "2", name="option" %> 登録済み住所から選択</h5>
+      <%= select_tag 'address_select', options_for_select(@delivery_addresses.map(&:pullarray_address), "-----") %><br>
+
+    <!-- -----------------------(3)新規の配達先を入力----------------------- -->
+    <h5><%= radio_button_tag :option, "3", name="option" %> 新規登録</h5>
+
     <span>宛名</span><%= f.text_field :receiver %><br>
-    <span>郵便番号</span><%= f.text_field :postal_code %><br>
-    <span>住所</span><%= f.text_field :delivery_address %><br>
+
+    <%= fields_for @delivery_address do |address| %>
+      <span>郵便番号</span><%= address.text_field :postal_code %><br>
+      <div class="field">
+        <%= address.label :都道府県 %><br />
+        <%= address.collection_select :prefecture_code, JpPrefecture::Prefecture.all, :code, :name ,include_blank: '都道府県' %>
+      </div>
+      <div class="field">
+        <%= address.label :市区町村 %><br />
+        <%= address.text_field :address_city, autofocus: true, autocomplete: "address_city" %>
+      </div>
+      <div class="field">
+        <%= address.label :番地 %><br />
+        <%= address.text_field :address_street, autofocus: true, autocomplete: "address_street" %>
+      </div>
+      <div class="field">
+        <%= address.label :建物 %><br />
+        <%= address.text_field :address_building, autofocus: true, autocomplete: "address_building" %>
+      </div>
+    <% end %>
+    <!-- ----------------------------------------------------------------- -->
     <%= f.submit "確認画面に進む" %>
   <% end %>
 

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -12,7 +12,7 @@
   				<td>
   					<p><%= @order.postal_code %></p>
 			  		<p><%= @order.delivery_address %></p>
-			  		<p><%= @order.user.family_name%><%= @order.user.first_name%></p>
+			  		<p><%= @order.receiver %></p>
 			  	</td>
   			</tr>
   			<tr>
@@ -39,7 +39,7 @@
  			  </tr>
   		  <tr>
   			  <td>ご請求金額</td>
-  			  <td>{ @order.total_prise + @order.postage }</td>
+  			  <td><%= @order.total_price + @order.postage %></td>
  			  </tr>
  			</tbody>
   	</table>
@@ -61,7 +61,7 @@
   		    <td><%= order_detail.product.product_name %></td>
   		    <td><%= order_detail.product_price %></td>
   		    <td><%= order_detail.number %></td>
-  		    <td>#{ order_detail.number * order_detail.product_price }</td>
+  		    <td><%= order_detail.number * order_detail.product_price %></td>
         </tr>
   		<% end %>
  		</tbody>

--- a/db/migrate/20200603123207_rename_portal_code_column_to_delivery_addresses.rb
+++ b/db/migrate/20200603123207_rename_portal_code_column_to_delivery_addresses.rb
@@ -1,0 +1,5 @@
+class RenamePortalCodeColumnToDeliveryAddresses < ActiveRecord::Migration[5.2]
+  def change
+  	rename_column :delivery_addresses, :portal_code, :postal_code
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_06_02_101448) do
+ActiveRecord::Schema.define(version: 2020_06_03_123207) do
 
   create_table "admins", force: :cascade do |t|
     t.string "email", default: "", null: false
@@ -42,7 +42,7 @@ ActiveRecord::Schema.define(version: 2020_06_02_101448) do
   create_table "delivery_addresses", force: :cascade do |t|
     t.integer "user_id"
     t.string "receiver"
-    t.string "portal_code"
+    t.string "postal_code"
     t.string "prefecture_code"
     t.string "address_city"
     t.string "address_street"


### PR DESCRIPTION
・注文情報入力画面の配達先の選択方法を追加（完成）
・住所の連結メソッドを修正
   県名が数字になってしまっていたのを修正しました。
・ユーザー名の連結メソッドを定義
　使い方：@user.user_fullname →　@userのフルネームが表示されます。
・DBのカラム名を修正
　delivery_addressモデル　：portal_code => postal_code